### PR TITLE
feat: Add vignettes for ggsaveR

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,6 @@
 ^ggsaveR\.Rproj$
 ^\.Rproj\.user$
+^vignettes/.*\.Rmd$
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^docs$

--- a/vignettes/advanced-techniques.Rmd
+++ b/vignettes/advanced-techniques.Rmd
@@ -1,0 +1,96 @@
+---
+title: "Advanced Techniques with ggsaveR"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Advanced Techniques with ggsaveR}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Introduction
+
+This vignette covers the most advanced features of `ggsaveR`, focusing on reproducibility and fine-grained control. We will explore how to embed reproducibility data into PNG files and how to use the `guard` argument to bypass global settings for specific `ggsave()` calls.
+
+```{r}
+library(ggplot2)
+library(ggsaveR)
+```
+
+## Reproducibility: Embedding Data in PNGs
+
+For maximum reproducibility, `ggsaveR` can embed the `ggplot` object, the R code that generated it, and session information directly into the PNG file's metadata. This is controlled by the `ggsaveR.embed_data` option.
+
+```{r}
+options(ggsaveR.embed_data = TRUE)
+```
+
+When this option is `TRUE`, any plot saved as a PNG will contain this extra information. `ggsaveR` captures the plot-generating code, even when using pipes.
+
+```{r, eval=FALSE}
+# The plot object and the code below are embedded in the PNG file
+iris |>
+  subset(Species != "setosa") |>
+  ggplot(aes(Sepal.Length, Petal.Length)) +
+  geom_point(aes(color = Species)) |>
+  ggsave("plot_with_embedded_data.png")
+```
+
+You can then use the `read_ggsaveR_data()` function to extract this information from the saved PNG.
+
+```{r, eval=FALSE}
+# Read the embedded data
+embedded_info <- read_ggsaveR_data("plot_with_embedded_data.png")
+
+# View the code that generated the plot
+cat(embedded_info$plot_call)
+#> iris |>
+#>   subset(Species != "setosa") |>
+#>   ggplot(aes(Sepal.Length, Petal.Length)) +
+#>   geom_point(aes(color = Species))
+
+# You can even replot the original ggplot object
+# embedded_info$plot_object
+```
+
+```{r}
+# Reset the option
+options(ggsaveR.embed_data = FALSE)
+```
+
+## The Escape Hatch: `guard = TRUE`
+
+Sometimes you have global options set but need to bypass them for a single, specific `ggsave()` call. The `guard = TRUE` argument serves as an "escape hatch," telling `ggsaveR` to step aside and pass the call directly to the original `ggplot2::ggsave`.
+
+### Use Case: Preventing Sensitive Data Embedding
+
+Imagine you have `ggsaveR.embed_data = TRUE` set globally for reproducibility. However, one specific plot is generated from sensitive or very large data that you do not want to embed in the PNG file.
+
+```{r, eval=FALSE}
+# Global setting for reproducibility
+options(ggsaveR.embed_data = TRUE)
+
+# This plot contains sensitive information
+sensitive_data <- data.frame(
+  x = rnorm(10),
+  y = rnorm(10),
+  secret = "Confidential Information"
+)
+p_sensitive <- ggplot(sensitive_data, aes(x, y)) + geom_point()
+
+# Use guard = TRUE to save the plot without embedding the data
+# This call will use the standard ggplot2::ggsave behavior
+ggsave("sensitive_plot.png", p_sensitive, guard = TRUE)
+```
+
+The `guard = TRUE` argument ensures that for this one call, none of the `ggsaveR` enhancements are applied. The plot will be saved as a standard PNG, without any embedded data, and it will overwrite any existing file with the same name, regardless of the `ggsaveR.overwrite_action` setting.
+
+> **Warning:** Using `guard = TRUE` in a script requires that the `ggsaveR` package is loaded. If it is not, the original `ggplot2::ggsave` will throw an "unused argument" error for `guard`.
+
+These advanced features make `ggsaveR` a powerful tool for managing complex data analysis workflows, enhancing reproducibility while providing the flexibility to handle exceptions.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,0 +1,74 @@
+---
+title: "Getting Started with ggsaveR"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting Started with ggsaveR}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Introduction
+
+The `ggsaveR` package is designed to supercharge `ggplot2::ggsave()` without requiring you to change your existing code. This vignette will walk you through the simplest, most common use case: making `ggsave()` better with a single line of code.
+
+## The Problem
+
+Imagine you have an analysis script that saves several plots.
+
+```{r}
+library(ggplot2)
+
+# Create a plot
+p <- ggplot(mtcars, aes(mpg, wt)) +
+  geom_point() +
+  labs(title = "Fuel Efficiency vs. Weight")
+
+# Save the plot
+# In a real script, you might save this in a 'figures' directory
+# ggsave("figures/mpg_vs_wt.png", p)
+```
+
+If you want to change how the plot is saved—for example, to add a PDF version for a publication—you would normally have to find and modify every `ggsave()` call.
+
+## The `ggsaveR` Solution
+
+With `ggsaveR`, you can set global options to control the behavior of all subsequent `ggsave()` calls.
+
+First, load the `ggsaveR` library.
+
+```{r}
+library(ggsaveR)
+```
+
+Now, let's say you want every plot to be saved as both a PNG and a PDF. You can set the `ggsaveR.formats` option at the top of your script.
+
+```{r}
+options(ggsaveR.formats = list(
+  list(device = "png", dpi = 300),
+  list(device = "pdf")
+))
+```
+
+Now, when you call `ggsave()`, it will automatically save to both formats. The file extension in the `filename` argument is used as the base name.
+
+```{r, eval=FALSE}
+# This single call will create both "mpg_vs_wt.png" and "mpg_vs_wt.pdf"
+ggsave("mpg_vs_wt.png", p)
+```
+
+This simple setup allows you to enhance all plot-saving operations in an existing project by adding just two lines of code to the top of your script.
+
+To clean up, you can reset the option to `NULL`.
+
+```{r}
+options(ggsaveR.formats = NULL)
+```
+
+This vignette has shown the most basic feature of `ggsaveR`. The other vignettes in this series will explore more advanced capabilities.

--- a/vignettes/intermediate-usage.Rmd
+++ b/vignettes/intermediate-usage.Rmd
@@ -1,0 +1,103 @@
+---
+title: "Intermediate Usage of ggsaveR"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Intermediate Usage of ggsaveR}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Introduction
+
+This vignette builds on the basics covered in "Getting Started with ggsaveR" and explores more advanced features, such as saving plots in multiple dimensions and preventing accidental file overwrites.
+
+```{r}
+library(ggplot2)
+library(ggsaveR)
+
+# Create a sample plot
+p <- ggplot(iris, aes(Sepal.Length, Petal.Length, color = Species)) +
+  geom_point() +
+  labs(title = "Sepal Length vs. Petal Length")
+```
+
+## Saving Multiple Formats and Dimensions
+
+In the previous vignette, we saw how to save a plot in multiple formats. The `ggsaveR.formats` option is highly flexible and allows you to specify different dimensions, resolutions, and other parameters for each file.
+
+Let's define a set of formats for different purposes: a high-resolution PNG for a presentation, a PDF for a manuscript, and an SVG for web use.
+
+```{r}
+options(ggsaveR.formats = list(
+  # A high-res PNG for presentations
+  list(device = "png", width = 8, height = 5, units = "in", dpi = 300),
+  # A PDF for a manuscript, with dimensions in centimeters
+  list(device = "pdf", width = 18, height = 11, units = "cm"),
+  # An SVG for web/editing
+  list(device = "svg", width = 7, height = 4.5)
+))
+```
+
+Now, a single `ggsave()` call will generate all three files with their respective specifications. The original file extension is ignored, and the `filename` is used as a base name.
+
+```{r, eval=FALSE}
+# This creates "iris_plot.png", "iris_plot.pdf", and "iris_plot.svg"
+ggsave("outputs/iris_plot.png", p)
+```
+
+```{r}
+# Reset the option
+options(ggsaveR.formats = NULL)
+```
+
+## Preventing File Overwrites
+
+During a long analysis, you might accidentally overwrite a critical plot. `ggsaveR` provides the `ggsaveR.overwrite_action` option to control this behavior.
+
+The default is `"overwrite"`, which mimics the standard `ggplot2::ggsave` behavior.
+
+### Stop on Existing File
+
+Set the option to `"stop"` to throw an error if the file already exists. This is useful for preventing accidental overwrites in critical scripts.
+
+```{r, eval = FALSE}
+options(ggsaveR.overwrite_action = "stop")
+
+# This will work the first time
+ggsave("critical_plot.png", p)
+
+# If you run it again, it will throw an error
+# ggsave("critical_plot.png", p)
+# Error: File 'critical_plot.png' already exists and ggsaveR.overwrite_action is set to 'stop'.
+```
+
+### Create a Unique Filename
+
+Alternatively, you can set the option to `"unique"` to automatically generate a new filename if the intended one already exists. This is useful for iterative analyses where you want to keep all versions of a plot.
+
+```{r, eval = FALSE}
+options(ggsaveR.overwrite_action = "unique")
+
+# Run this once: creates "versioned_plot.png"
+ggsave("versioned_plot.png", p)
+
+# Run this again: creates "versioned_plot-1.png"
+ggsave("versioned_plot.png", p)
+
+# And again: creates "versioned_plot-2.png"
+ggsave("versioned_plot.png", p)
+```
+
+```{r}
+# Reset to default
+options(ggsaveR.overwrite_action = "overwrite")
+```
+
+These intermediate features provide a much finer level of control over how your plots are saved, helping to streamline your workflow and protect your work.


### PR DESCRIPTION
This commit introduces three new vignettes to the `ggsaveR` package:

- `getting-started.Rmd`: A basic introduction to the package.
- `intermediate-usage.Rmd`: Demonstrates more advanced features like saving multiple formats and preventing overwrites.
- `advanced-techniques.Rmd`: Showcases the most powerful features, such as embedding reproducibility data and using the `guard` argument.

These vignettes provide comprehensive documentation and examples to help you understand and utilize the full potential of `ggsaveR`.